### PR TITLE
Load the Gravatar images using the same protocol as the host.

### DIFF
--- a/src/ui/library/components/avatar.hb
+++ b/src/ui/library/components/avatar.hb
@@ -11,24 +11,24 @@
 
         <div class="js-tab tabbed__content" id="examples">
             <h2>Examples</h2>   
-            <div><a href="#" class="avatar"><img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="40" height="40"></a></div>
-            <div><a href="#" class="avatar"><img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="60" height="60"></a></div>
-            <div><a href="#" class="avatar"><img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="80" height="80"></a></div>
+            <div><a href="#" class="avatar"><img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="40" height="40"></a></div>
+            <div><a href="#" class="avatar"><img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="60" height="60"></a></div>
+            <div><a href="#" class="avatar"><img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="80" height="80"></a></div>
         </div>
 
         <div class="js-tab tabbed__content" id="code">
             <h2>Code</h2>
             {{#> code-sample }}
 <a href="#" class="avatar">
-    <img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="40" height="40">
+    <img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="40" height="40">
 </a>
 
 <a href="#" class="avatar">
-    <img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="60" height="60">
+    <img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="60" height="60">
 </a>
 
 <a href="#" class="avatar">
-    <img src="http://0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="80" height="80">
+    <img src="//0.gravatar.com/avatar/03226922ef183e52ba8a3cfdb19ca855" alt="" width="80" height="80">
 </a>
             {{/code-sample}}
         </div>


### PR DESCRIPTION
As requested by @rmc47 [here](https://github.com/red-gate/IS-Deployment/pull/1702#issuecomment-1047882821), which will in turn help with the PR at https://github.com/red-gate/IS-Deployment/pull/1702 to fix the CSP (content security policy) issues (raised in https://github.com/red-gate/honeycomb-web-toolkit/issues/316).